### PR TITLE
Implement of getting current user api and adjust audio logic

### DIFF
--- a/src/SugarTalk.Api/Controllers/AccountController.cs
+++ b/src/SugarTalk.Api/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 using Mediator.Net;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SugarTalk.Messages.Requests.Account;
 
@@ -21,6 +22,16 @@ public class AccountController : ControllerBase
     {
         var response = await _mediator.RequestAsync<LoginRequest, LoginResponse>(request);
 
+        return Ok(response);
+    }
+    
+    [Authorize]
+    [Route("user"), HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GetCurrentUserResponse))]
+    public async Task<IActionResult> GetCurrentUserAsync([FromQuery] GetCurrentUserRequest request)
+    {
+        var response = await _mediator.RequestAsync<GetCurrentUserRequest, GetCurrentUserResponse>(request);
+        
         return Ok(response);
     }
 }

--- a/src/SugarTalk.Api/Controllers/AccountController.cs
+++ b/src/SugarTalk.Api/Controllers/AccountController.cs
@@ -1,6 +1,6 @@
 using Mediator.Net;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using SugarTalk.Messages.Requests.Account;
 
 namespace SugarTalk.Api.Controllers;

--- a/src/SugarTalk.Core/Handlers/CommandHandlers/Meetings/ChangeAudioCommandHandler.cs
+++ b/src/SugarTalk.Core/Handlers/CommandHandlers/Meetings/ChangeAudioCommandHandler.cs
@@ -27,7 +27,6 @@ public class ChangeAudioCommandHandler : ICommandHandler<ChangeAudioCommand, Cha
         {
             Data = new ChangeAudioResponseData
             {
-                Response = @event.Response,
                 MeetingUserSession = @event.MeetingUserSession
             }
         };

--- a/src/SugarTalk.Core/Handlers/CommandHandlers/Meetings/ShareScreenCommandHandler.cs
+++ b/src/SugarTalk.Core/Handlers/CommandHandlers/Meetings/ShareScreenCommandHandler.cs
@@ -26,7 +26,6 @@ public class ShareScreenCommandHandler : ICommandHandler<ShareScreenCommand, Sha
         {
             Data = new ShareScreenResponseData
             {
-                Response = @event.Response,
                 MeetingUserSession = @event.MeetingUserSession
             }
         };

--- a/src/SugarTalk.Core/Handlers/RequestHandlers/Account/GetCurrentUserRequestHandler.cs
+++ b/src/SugarTalk.Core/Handlers/RequestHandlers/Account/GetCurrentUserRequestHandler.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Mediator.Net.Context;
+using Mediator.Net.Contracts;
+using SugarTalk.Core.Services.Account;
+using SugarTalk.Messages.Requests.Account;
+
+namespace SugarTalk.Core.Handlers.RequestHandlers.Account;
+
+public class GetCurrentUserRequestHandler : IRequestHandler<GetCurrentUserRequest, GetCurrentUserResponse>
+{
+    private readonly IAccountService _accountService;
+
+    public GetCurrentUserRequestHandler(IAccountService accountService)
+    {
+        _accountService = accountService;
+    }
+
+    public async Task<GetCurrentUserResponse> Handle(IReceiveContext<GetCurrentUserRequest> context, CancellationToken cancellationToken)
+    {
+        return await _accountService.GetCurrentUserAsync(context.Message, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/SugarTalk.Core/Handlers/RequestHandlers/Account/GetCurrentUserRequestHandler.cs
+++ b/src/SugarTalk.Core/Handlers/RequestHandlers/Account/GetCurrentUserRequestHandler.cs
@@ -1,6 +1,6 @@
 using System.Threading;
-using System.Threading.Tasks;
 using Mediator.Net.Context;
+using System.Threading.Tasks;
 using Mediator.Net.Contracts;
 using SugarTalk.Core.Services.Account;
 using SugarTalk.Messages.Requests.Account;

--- a/src/SugarTalk.Core/Services/Account/AccountDataProvider.cs
+++ b/src/SugarTalk.Core/Services/Account/AccountDataProvider.cs
@@ -63,8 +63,8 @@ namespace SugarTalk.Core.Services.Account
             await _repository.InsertAsync(user, cancellationToken).ConfigureAwait(false);
         }
         
-        public async Task<UserAccountDto> GetUserAccountAsync(int? id = null, string username = null, string thirdPartyUserId = null, bool includeRoles = false,
-            CancellationToken cancellationToken = default)
+        public async Task<UserAccountDto> GetUserAccountAsync(
+            int? id = null, string username = null, string thirdPartyUserId = null, bool includeRoles = false, CancellationToken cancellationToken = default)
         {
             var query = _repository.QueryNoTracking<UserAccount>();
 

--- a/src/SugarTalk.Core/Services/Account/AccountService.cs
+++ b/src/SugarTalk.Core/Services/Account/AccountService.cs
@@ -17,7 +17,7 @@ namespace SugarTalk.Core.Services.Account
     {
         Task<LoginResponse> LoginAsync(LoginRequest request, CancellationToken cancellationToken);
         
-        Task<UserAccountDto> GetCurrentUserAsync(CancellationToken cancellationToken);
+        Task<GetCurrentUserResponse> GetCurrentUserAsync(GetCurrentUserRequest request, CancellationToken cancellationToken);
         
         Task<UserAccountRegisteredEvent> RegisterAsync(RegisterCommand command, CancellationToken cancellationToken);
         
@@ -27,17 +27,17 @@ namespace SugarTalk.Core.Services.Account
     public class AccountService : IAccountService
     {
         private readonly IMapper _mapper;
-        private readonly ICurrentUser _currentUser;
         private readonly ITokenProvider _tokenProvider;
+        private readonly IIdentityService _identityService;
         private readonly IHttpContextAccessor _httpContextAccessor;
         
         private readonly IAccountDataProvider _accountDataProvider;
 
-        public AccountService(IMapper mapper, ICurrentUser currentUser, IHttpContextAccessor httpContextAccessor, IAccountDataProvider accountDataProvider, ITokenProvider tokenProvider)
+        public AccountService(IMapper mapper, IIdentityService identityService, IHttpContextAccessor httpContextAccessor, IAccountDataProvider accountDataProvider, ITokenProvider tokenProvider)
         {
             _mapper = mapper;
-            _currentUser = currentUser;
             _tokenProvider = tokenProvider;
+            _identityService = identityService;
             _accountDataProvider = accountDataProvider;
             _httpContextAccessor = httpContextAccessor;
         }
@@ -56,10 +56,12 @@ namespace SugarTalk.Core.Services.Account
             };
         }
         
-        public async Task<UserAccountDto> GetCurrentUserAsync(CancellationToken cancellationToken)
+        public async Task<GetCurrentUserResponse> GetCurrentUserAsync(GetCurrentUserRequest request, CancellationToken cancellationToken)
         {
-            return await _accountDataProvider
-                .GetUserAccountAsync(id: _currentUser.Id, includeRoles: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return new GetCurrentUserResponse
+            {
+                Data = await _identityService.GetCurrentUserAsync(cancellationToken: cancellationToken).ConfigureAwait(false)
+            };
         }
 
         public async Task<UserAccountDto> GetOrCreateUserAccountFromThirdPartyAsync(string userId, string userName, CancellationToken cancellationToken)

--- a/src/SugarTalk.Core/Services/Identity/ICurrentUser.cs
+++ b/src/SugarTalk.Core/Services/Identity/ICurrentUser.cs
@@ -9,7 +9,7 @@ namespace SugarTalk.Core.Services.Identity;
 
 public interface ICurrentUser
 {
-    int Id { get; }
+    int? Id { get; }
     
     UserAccountIssuer AuthType { get; }
 }
@@ -23,16 +23,16 @@ public class CurrentUser : ICurrentUser
         _httpContextAccessor = httpContextAccessor;
     }
 
-    public int Id
+    public int? Id
     {
         get
         {
-            if (_httpContextAccessor.HttpContext == null)
-                throw new ApplicationException("HttpContext is not available");
+            if (_httpContextAccessor?.HttpContext == null) return null;
 
-            var idClaim = _httpContextAccessor.HttpContext.User.Claims.Single(x => x.Type == ClaimTypes.NameIdentifier);
+            var idClaim = _httpContextAccessor.HttpContext.User.Claims
+                .SingleOrDefault(x => x.Type == ClaimTypes.NameIdentifier)?.Value;
 
-            return int.Parse(idClaim.Value);
+            return int.TryParse(idClaim, out var id) ? id : null;
         }
     }
 
@@ -54,7 +54,7 @@ public class CurrentUser : ICurrentUser
 
 public class InternalUser : ICurrentUser
 {
-    public int Id => 1;
+    public int? Id => 1;
 
     public UserAccountIssuer AuthType => UserAccountIssuer.Wiltechs;
 }

--- a/src/SugarTalk.Core/Services/Identity/IIdentityService.cs
+++ b/src/SugarTalk.Core/Services/Identity/IIdentityService.cs
@@ -1,10 +1,13 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using SugarTalk.Core.Ioc;
+using SugarTalk.Messages.Dto.Users;
 
 namespace SugarTalk.Core.Services.Identity;
 
 public interface IIdentityService : IScopedDependency
 {
     Task<bool> IsInRolesAsync(int userId, string[] rolesArray, CancellationToken cancellationToken);
+    
+    Task<UserAccountDto> GetCurrentUserAsync(bool throwWhenNotFound = false, CancellationToken cancellationToken = default);
 }

--- a/src/SugarTalk.Core/Services/Meetings/MeetingDataProvider.UserSession.cs
+++ b/src/SugarTalk.Core/Services/Meetings/MeetingDataProvider.UserSession.cs
@@ -110,6 +110,8 @@ public partial class MeetingDataProvider
         if (userSessionStreams is not { Count: > 0 }) return;
 
         await _repository.DeleteAllAsync(userSessionStreams, cancellationToken).ConfigureAwait(false);
+        
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task RemoveMeetingUserSessionsIfRequiredAsync(int userId, Guid meetingId, CancellationToken cancellationToken)

--- a/src/SugarTalk.Core/Services/Meetings/MeetingDataProvider.UserSession.cs
+++ b/src/SugarTalk.Core/Services/Meetings/MeetingDataProvider.UserSession.cs
@@ -110,8 +110,6 @@ public partial class MeetingDataProvider
         if (userSessionStreams is not { Count: > 0 }) return;
 
         await _repository.DeleteAllAsync(userSessionStreams, cancellationToken).ConfigureAwait(false);
-        
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task RemoveMeetingUserSessionsIfRequiredAsync(int userId, Guid meetingId, CancellationToken cancellationToken)

--- a/src/SugarTalk.Core/Services/Meetings/MeetingService.UserSession.cs
+++ b/src/SugarTalk.Core/Services/Meetings/MeetingService.UserSession.cs
@@ -29,15 +29,9 @@ public partial class MeetingService
 
         if (meeting == null) throw new MeetingNotFoundException();
 
-        if (command.IsMuted)
-        {
-            if (userSession.UserId != _currentUser.Id)
-                throw new CannotChangeAudioWhenConfirmRequiredException();
+        if (command.IsMuted && userSession.UserId != _currentUser.Id) throw new CannotChangeAudioWhenConfirmRequiredException();
 
-            userSession.IsMuted = command.IsMuted;
-        }
-        else
-            userSession.IsMuted = false;
+        userSession.IsMuted = command.IsMuted;
 
         await _meetingDataProvider.UpdateMeetingUserSessionAsync(userSession, cancellationToken).ConfigureAwait(false);
 

--- a/src/SugarTalk.Core/Services/Meetings/MeetingService.UserSession.cs
+++ b/src/SugarTalk.Core/Services/Meetings/MeetingService.UserSession.cs
@@ -29,22 +29,20 @@ public partial class MeetingService
 
         if (meeting == null) throw new MeetingNotFoundException();
 
+        await RemoveMeetingUserSessionStreamAsync(userSession.Id, MeetingStreamType.Audio, cancellationToken).ConfigureAwait(false);
+        
         if (command.IsMuted)
         {
             if (userSession.UserId != _currentUser.Id)
                 throw new CannotChangeAudioWhenConfirmRequiredException();
 
-            userSession.IsMuted = true;
+            userSession.IsMuted = command.IsMuted;
             
             await AddMeetingUserSessionStreamAsync(
                 userSession.Id, command.StreamId, MeetingStreamType.Audio, cancellationToken).ConfigureAwait(false);
         }
         else
-        {
             userSession.IsMuted = false;
-
-            await RemoveMeetingUserSessionStreamAsync(userSession.Id, MeetingStreamType.Audio, cancellationToken).ConfigureAwait(false);
-        }
 
         await _meetingDataProvider.UpdateMeetingUserSessionAsync(userSession, cancellationToken).ConfigureAwait(false);
 

--- a/src/SugarTalk.Core/Services/Meetings/MeetingService.UserSession.cs
+++ b/src/SugarTalk.Core/Services/Meetings/MeetingService.UserSession.cs
@@ -29,17 +29,12 @@ public partial class MeetingService
 
         if (meeting == null) throw new MeetingNotFoundException();
 
-        await RemoveMeetingUserSessionStreamAsync(userSession.Id, MeetingStreamType.Audio, cancellationToken).ConfigureAwait(false);
-        
         if (command.IsMuted)
         {
             if (userSession.UserId != _currentUser.Id)
                 throw new CannotChangeAudioWhenConfirmRequiredException();
 
             userSession.IsMuted = command.IsMuted;
-            
-            await AddMeetingUserSessionStreamAsync(
-                userSession.Id, command.StreamId, MeetingStreamType.Audio, cancellationToken).ConfigureAwait(false);
         }
         else
             userSession.IsMuted = false;

--- a/src/SugarTalk.Core/Services/Meetings/MeetingService.cs
+++ b/src/SugarTalk.Core/Services/Meetings/MeetingService.cs
@@ -196,10 +196,16 @@ namespace SugarTalk.Core.Services.Meetings
                 
                 var updateUserSession = _mapper.Map<MeetingUserSessionDto>(userSession);
 
-                var userSessionStream =
-                    await AddMeetingUserSessionStreamIfRequiredAsync(updateUserSession.Id, streamId, streamType, cancellationToken).ConfigureAwait(false);
+                if (isMuted == true)
+                {
+                    var userSessionStream =
+                        await AddMeetingUserSessionStreamIfRequiredAsync(updateUserSession.Id, streamId, streamType, cancellationToken).ConfigureAwait(false);
 
-                updateUserSession.UserSessionStreams = new List<MeetingUserSessionStreamDto> { userSessionStream };
+                    updateUserSession.UserSessionStreams = new List<MeetingUserSessionStreamDto> { userSessionStream };
+                    
+                    await _antMediaServerUtilService
+                        .AddStreamToMeetingAsync(appName, meeting.MeetingNumber, streamId, cancellationToken).ConfigureAwait(false);
+                }
 
                 updateUserSession.UserName = user.UserName;
                 

--- a/src/SugarTalk.Core/Services/Meetings/MeetingService.cs
+++ b/src/SugarTalk.Core/Services/Meetings/MeetingService.cs
@@ -78,7 +78,7 @@ namespace SugarTalk.Core.Services.Meetings
             
             var meeting = new Meeting
             {
-                MeetingMasterUserId = _currentUser.Id,
+                MeetingMasterUserId = _currentUser.Id.Value,
                 MeetingStreamMode = command.MeetingStreamMode,
                 MeetingNumber = response.MeetingNumber,
                 OriginAddress = response.OriginAddress,
@@ -130,7 +130,7 @@ namespace SugarTalk.Core.Services.Meetings
         public async Task<MeetingOutedEvent> OutMeetingAsync(OutMeetingCommand command, CancellationToken cancellationToken)
         {
             var userSession = await _meetingDataProvider
-                .GetMeetingUserSessionByMeetingIdAsync(command.MeetingId, _currentUser.Id, cancellationToken).ConfigureAwait(false);
+                .GetMeetingUserSessionByMeetingIdAsync(command.MeetingId, _currentUser.Id.Value, cancellationToken).ConfigureAwait(false);
 
             if (userSession == null) return new MeetingOutedEvent();
 

--- a/src/SugarTalk.Core/Services/Meetings/MeetingService.cs
+++ b/src/SugarTalk.Core/Services/Meetings/MeetingService.cs
@@ -195,14 +195,11 @@ namespace SugarTalk.Core.Services.Meetings
                 await _meetingDataProvider.AddMeetingUserSessionAsync(userSession, cancellationToken).ConfigureAwait(false);
                 
                 var updateUserSession = _mapper.Map<MeetingUserSessionDto>(userSession);
+                
+                var userSessionStream =
+                    await AddMeetingUserSessionStreamIfRequiredAsync(updateUserSession.Id, streamId, streamType, cancellationToken).ConfigureAwait(false);
 
-                if (isMuted == true)
-                {
-                    var userSessionStream =
-                        await AddMeetingUserSessionStreamIfRequiredAsync(updateUserSession.Id, streamId, streamType, cancellationToken).ConfigureAwait(false);
-
-                    updateUserSession.UserSessionStreams = new List<MeetingUserSessionStreamDto> { userSessionStream };
-                }
+                updateUserSession.UserSessionStreams = new List<MeetingUserSessionStreamDto> { userSessionStream };
 
                 updateUserSession.UserName = user.UserName;
                 

--- a/src/SugarTalk.Core/Services/Meetings/MeetingService.cs
+++ b/src/SugarTalk.Core/Services/Meetings/MeetingService.cs
@@ -202,9 +202,6 @@ namespace SugarTalk.Core.Services.Meetings
                         await AddMeetingUserSessionStreamIfRequiredAsync(updateUserSession.Id, streamId, streamType, cancellationToken).ConfigureAwait(false);
 
                     updateUserSession.UserSessionStreams = new List<MeetingUserSessionStreamDto> { userSessionStream };
-                    
-                    await _antMediaServerUtilService
-                        .AddStreamToMeetingAsync(appName, meeting.MeetingNumber, streamId, cancellationToken).ConfigureAwait(false);
                 }
 
                 updateUserSession.UserName = user.UserName;

--- a/src/SugarTalk.Core/SugarTalk.Core.csproj
+++ b/src/SugarTalk.Core/SugarTalk.Core.csproj
@@ -46,10 +46,6 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.4" />
     </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Validators" />
-    </ItemGroup>
     
     <ItemGroup>
         <EmbeddedResource Include="DbUp\Scripts_2023\Script0001_initial_tables.sql" />

--- a/src/SugarTalk.Core/Validators/Commands/JoinMeetingCommandValidator.cs
+++ b/src/SugarTalk.Core/Validators/Commands/JoinMeetingCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using SugarTalk.Core.Middlewares.FluentMessageValidator;
+using SugarTalk.Messages.Commands.Meetings;
+
+namespace SugarTalk.Core.Validators.Commands;
+
+public class JoinMeetingCommandValidator : FluentMessageValidator<JoinMeetingCommand>
+{
+    public JoinMeetingCommandValidator()
+    {
+        RuleFor(x => x.StreamId).NotNull();
+        RuleFor(x => x.MeetingNumber).NotNull();
+    }
+}

--- a/src/SugarTalk.IntegrationTests/Services/Account/AccountFixture.cs
+++ b/src/SugarTalk.IntegrationTests/Services/Account/AccountFixture.cs
@@ -209,6 +209,17 @@ public class AccountFixture : AccountFixtureBase
             afterUserAccount.ThirdPartyUserId.ShouldBe(beforeUserAccount.ThirdPartyUserId);
         });
     }
+    
+    [Fact]
+    public async Task CanGetCurrentUser()
+    {
+        await Run<IMediator>(async mediator =>
+        {
+            var response = await mediator.RequestAsync<GetCurrentUserRequest, GetCurrentUserResponse>(new GetCurrentUserRequest());
+
+            response.Data.ShouldNotBeNull();
+        });
+    }
 
     private async Task MarkUserAccountAsUnActivate(UserAccount userAccount)
     {

--- a/src/SugarTalk.IntegrationTests/Services/Meeting/MeetingServiceFixture.cs
+++ b/src/SugarTalk.IntegrationTests/Services/Meeting/MeetingServiceFixture.cs
@@ -100,7 +100,7 @@ public class MeetingServiceFixture : MeetingFixtureBase
 
         var meeting = await _meetingUtil.GetMeeting(scheduleMeetingResponse.Data.MeetingNumber);
 
-        await _meetingUtil.JoinMeeting(meeting.MeetingNumber);
+        await _meetingUtil.JoinMeeting(meeting.MeetingNumber, "streamId");
 
         await Run<IMediator, IRepository>(async (mediator, repository) =>
         {
@@ -141,8 +141,8 @@ public class MeetingServiceFixture : MeetingFixtureBase
 
             var meeting = await _meetingUtil.GetMeeting(scheduleMeetingResponse.Data.MeetingNumber);
 
-            await _meetingUtil.JoinMeeting(meeting.MeetingNumber);
-            await _meetingUtil.JoinMeeting(meeting.MeetingNumber);
+            await _meetingUtil.JoinMeeting(meeting.MeetingNumber, "streamId1");
+            await _meetingUtil.JoinMeeting(meeting.MeetingNumber, "streamId2");
         }
         catch (Exception ex)
         {
@@ -159,7 +159,7 @@ public class MeetingServiceFixture : MeetingFixtureBase
 
         var meeting = await _meetingUtil.GetMeeting(scheduleMeetingResponse.Data.MeetingNumber);
 
-        await _meetingUtil.JoinMeeting(meeting.MeetingNumber);
+        await _meetingUtil.JoinMeeting(meeting.MeetingNumber, "streamId");
         
         await Run<IMediator, IRepository>(async (mediator, repository) =>
         {
@@ -200,7 +200,7 @@ public class MeetingServiceFixture : MeetingFixtureBase
         var user1 = await _accountUtil.AddUserAccount("mars", "123");
         var user2 = await _accountUtil.AddUserAccount("greg", "123");
 
-        await _meetingUtil.JoinMeeting(scheduleMeetingResponse.Data.MeetingNumber);
+        await _meetingUtil.JoinMeeting(scheduleMeetingResponse.Data.MeetingNumber, "streamId");
 
         await Run<IMediator, IRepository, IUnitOfWork>(async (mediator, repository, unitOfWork) =>
         {
@@ -311,34 +311,26 @@ public class MeetingServiceFixture : MeetingFixtureBase
     {
         var scheduleMeetingResponse = await _meetingUtil.ScheduleMeeting();
 
-        var meeting = await _meetingUtil.GetMeeting(scheduleMeetingResponse.Data.MeetingNumber);
+        var joinMeeting =
+            await _meetingUtil.JoinMeeting(scheduleMeetingResponse.Data.MeetingNumber, "streamId", !isMuted);
 
-        var user2 = await _accountUtil.AddUserAccount("test2", "123");
+        var userSessionId = joinMeeting.UserSessions.Single().Id;
 
-        await Run<IMediator, ICurrentUser>(async (mediator, currentUser) =>
+        await Run<IMediator>(async (mediator) =>
         {
-            await _meetingUtil.AddMeetingUserSession(2, meeting.Id, user2.Id);
-            await _meetingUtil.AddMeetingUserSession(1, meeting.Id, currentUser.Id.Value);
-
             var response = await mediator.SendAsync<ChangeAudioCommand, ChangeAudioResponse>(
                 new ChangeAudioCommand
                 {
-                    MeetingUserSessionId = 1,
-                    StreamId = "123456",
+                    MeetingUserSessionId = userSessionId,
                     IsMuted = isMuted
                 });
 
             response.Data.MeetingUserSession.IsMuted.ShouldBe(expect);
 
-            if (isMuted)
-            {
-                response.Data.MeetingUserSession.UserSessionStreams.Count.ShouldBe(1);
-                response.Data.MeetingUserSession.UserSessionStreams.Single().StreamId.ShouldBe("123456");
-                response.Data.MeetingUserSession.UserSessionStreams.Single().MeetingUserSessionId.ShouldBe(1);
-                response.Data.MeetingUserSession.UserSessionStreams.Single().StreamType.ShouldBe(MeetingStreamType.Audio);
-            }
-            else
-                response.Data.MeetingUserSession.UserSessionStreams.ShouldNotBeNull();
+            response.Data.MeetingUserSession.UserSessionStreams.Count.ShouldBe(1);
+            response.Data.MeetingUserSession.UserSessionStreams.Single().StreamId.ShouldBe("streamId");
+            response.Data.MeetingUserSession.UserSessionStreams.Single().MeetingUserSessionId.ShouldBe(userSessionId);
+            response.Data.MeetingUserSession.UserSessionStreams.Single().StreamType.ShouldBe(MeetingStreamType.Audio);
         }, SetupMocking);
     }
 

--- a/src/SugarTalk.IntegrationTests/Services/Meeting/MeetingServiceFixture.cs
+++ b/src/SugarTalk.IntegrationTests/Services/Meeting/MeetingServiceFixture.cs
@@ -318,7 +318,7 @@ public class MeetingServiceFixture : MeetingFixtureBase
         await Run<IMediator, ICurrentUser>(async (mediator, currentUser) =>
         {
             await _meetingUtil.AddMeetingUserSession(2, meeting.Id, user2.Id);
-            await _meetingUtil.AddMeetingUserSession(1, meeting.Id, currentUser.Id);
+            await _meetingUtil.AddMeetingUserSession(1, meeting.Id, currentUser.Id.Value);
 
             var response = await mediator.SendAsync<ChangeAudioCommand, ChangeAudioResponse>(
                 new ChangeAudioCommand

--- a/src/SugarTalk.IntegrationTests/TestCurrentUser.cs
+++ b/src/SugarTalk.IntegrationTests/TestCurrentUser.cs
@@ -5,7 +5,7 @@ namespace SugarTalk.IntegrationTests;
 
 public class TestCurrentUser : ICurrentUser
 {
-    public int Id { get; init; } = 1;
+    public int? Id { get; init; } = 1;
 
     public UserAccountIssuer AuthType { get; set; }
 

--- a/src/SugarTalk.IntegrationTests/Utils/Account/IdentityUtil.cs
+++ b/src/SugarTalk.IntegrationTests/Utils/Account/IdentityUtil.cs
@@ -25,7 +25,7 @@ public class IdentityUtil : TestUtil
         {
             await repository.InsertAsync(new UserAccount
             {
-                Id = testUser.Id,
+                Id = testUser.Id.Value,
                 UserName = testUser.UserName,
                 Uuid = new Guid("c2af213e-df6e-11ed-b5ea-0242ac120002"),
                 Password = "123456",

--- a/src/SugarTalk.IntegrationTests/Utils/Meetings/MeetingUtil.cs
+++ b/src/SugarTalk.IntegrationTests/Utils/Meetings/MeetingUtil.cs
@@ -51,15 +51,18 @@ public class MeetingUtil : TestUtil
         });
     }
 
-    public async Task JoinMeeting(string meetingNumber, bool isMuted = false)
+    public async Task<MeetingDto> JoinMeeting(string meetingNumber, string streamId, bool isMuted = false)
     {
-        await Run<IMediator>(async (mediator) =>
+        return await Run<IMediator, MeetingDto>(async (mediator) =>
         {
-            await mediator.SendAsync<JoinMeetingCommand, JoinMeetingResponse>(new JoinMeetingCommand
+            var response = await mediator.SendAsync<JoinMeetingCommand, JoinMeetingResponse>(new JoinMeetingCommand
             {
                 MeetingNumber = meetingNumber,
+                StreamId = streamId,
                 IsMuted = isMuted
             });
+
+            return response.Data.Meeting;
         }, builder =>
         {
             var antMediaServerUtilService = Substitute.For<IAntMediaServerUtilService>();

--- a/src/SugarTalk.Messages/Commands/Meetings/ChangeAudioCommand.cs
+++ b/src/SugarTalk.Messages/Commands/Meetings/ChangeAudioCommand.cs
@@ -1,7 +1,6 @@
 using Mediator.Net.Contracts;
-using SugarTalk.Messages.Dto.Meetings;
-using SugarTalk.Messages.Dto.Users;
 using SugarTalk.Messages.Responses;
+using SugarTalk.Messages.Dto.Meetings;
 
 namespace SugarTalk.Messages.Commands.Meetings;
 
@@ -20,7 +19,5 @@ public class ChangeAudioResponse : SugarTalkResponse<ChangeAudioResponseData>
 
 public class ChangeAudioResponseData
 {
-    public ConferenceRoomResponseBaseDto Response { get; set; }
-        
     public MeetingUserSessionDto MeetingUserSession { get; set; }
 }

--- a/src/SugarTalk.Messages/Commands/Meetings/ShareScreenCommand.cs
+++ b/src/SugarTalk.Messages/Commands/Meetings/ShareScreenCommand.cs
@@ -1,7 +1,6 @@
 using Mediator.Net.Contracts;
-using SugarTalk.Messages.Dto.Meetings;
-using SugarTalk.Messages.Dto.Users;
 using SugarTalk.Messages.Responses;
+using SugarTalk.Messages.Dto.Meetings;
 
 namespace SugarTalk.Messages.Commands.Meetings;
 
@@ -20,7 +19,5 @@ public class ShareScreenResponse : SugarTalkResponse<ShareScreenResponseData>
 
 public class ShareScreenResponseData
 {
-    public ConferenceRoomResponseBaseDto Response { get; set; }
-        
     public MeetingUserSessionDto MeetingUserSession { get; set; }
 }

--- a/src/SugarTalk.Messages/Events/Meeting/AudioChangedEvent.cs
+++ b/src/SugarTalk.Messages/Events/Meeting/AudioChangedEvent.cs
@@ -6,8 +6,6 @@ namespace SugarTalk.Messages.Events.Meeting
 {
     public class AudioChangedEvent : IEvent
     {
-        public ConferenceRoomResponseBaseDto Response { get; set; }
-        
         public MeetingUserSessionDto MeetingUserSession { get; set; }
     }
 }

--- a/src/SugarTalk.Messages/Events/Meeting/ScreenSharedEvent.cs
+++ b/src/SugarTalk.Messages/Events/Meeting/ScreenSharedEvent.cs
@@ -6,8 +6,6 @@ namespace SugarTalk.Messages.Events.Meeting
 {
     public class ScreenSharedEvent : IEvent
     {
-        public ConferenceRoomResponseBaseDto Response { get; set; }
-        
         public MeetingUserSessionDto MeetingUserSession { get; set; }
     }
 }

--- a/src/SugarTalk.Messages/Requests/Account/GetCurrentUserRequest.cs
+++ b/src/SugarTalk.Messages/Requests/Account/GetCurrentUserRequest.cs
@@ -1,0 +1,13 @@
+using Mediator.Net.Contracts;
+using SugarTalk.Messages.Dto.Users;
+using SugarTalk.Messages.Responses;
+
+namespace SugarTalk.Messages.Requests.Account;
+
+public class GetCurrentUserRequest : IRequest
+{
+}
+
+public class GetCurrentUserResponse : SugarTalkResponse<UserAccountDto>
+{
+}


### PR DESCRIPTION
Close #65 
1. 优化获取currentUser的逻辑
2. 调整audio/change逻辑，修复加入会议后，调/Meeting/get接口获取不到userSessionStreams
3. 用户StreamId包括音频流和视频流
4. 增加validator验证加入会议传入参数
5. 调整CanChangeAudio测试